### PR TITLE
Add eslint and prettier config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   "extends": ["react-app", "eslint:recommended"],
   "ignorePatterns": ["node_modules"],
   "rules": {
-    "no-use-before-define": ["error", { "functions": true, "classes": true }],
+    "no-use-before-define": ["error"],
     "no-unused-vars": [
       "error",
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,17 @@
+{
+  "extends": ["react-app", "eslint:recommended"],
+  "ignorePatterns": ["node_modules"],
+  "rules": {
+    "no-use-before-define": ["error", { "functions": true, "classes": true }],
+    "no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "argsIgnorePattern": "^_",
+        "args": "all",
+        "ignoreRestSiblings": false
+      }
+    ]
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "arrowParens": "avoid",
+  "endOfLine": "auto",
+  "jsxSingleQuote": false,
+  "jsxBracketSameLine": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "javascript.validate.enable": false,
+  "prettier.configPath": ".prettierrc",
+  "prettier.prettierPath": "node_modules/prettier",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "eslint.alwaysShowStatus": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,9 +1278,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.10.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-          "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+          "version": "13.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -5335,9 +5335,9 @@
           }
         },
         "globals": {
-          "version": "13.10.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-          "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+          "version": "13.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -11143,6 +11143,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "prettier": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -36,5 +36,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "eslint": "^7.32.0",
+    "prettier": "^2.3.2"
   }
 }


### PR DESCRIPTION
### ESLint와 Prettier 적용
 
- **VSCode에  ESLint, Prettier 플러그인 설치필요**
- 저장 시 prettier가 formatting
- lint rule은 `eslint:recommended` 사용
- `no-use-before-define`, `no-unused-vars` rule 추가적용