### PR TITLE
add: PieChart component

### DIFF
--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -1,0 +1,46 @@
+import styles from './PieChart.module.css'
+
+const PieChart = ({ keyWordRank, totalCount }) => {
+  const pieColour = ['#D92414', '#F279A6', '#3279A6', '#808080']
+  let current_deg = -90
+
+  return (
+    <div className={styles.pieChart__container}>
+      <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" version="1.1">
+        {keyWordRank.map((el, idx) => {
+          const r = 25
+          const ratio = (el.count / totalCount) * 100
+          const rotate = `rotate(${current_deg})`
+          current_deg += 360 * (el.count / totalCount)
+
+          return (
+            <circle
+              r={r}
+              cx="50"
+              cy="50"
+              fill="transparent"
+              stroke={pieColour[idx]}
+              strokeWidth="50"
+              strokeDasharray={`calc(${ratio} * ${2 * Math.PI * r} / 100) ${2 * Math.PI * r}`}
+              transform-origin="50 50"
+              transform={rotate}
+              key={idx}
+            />
+          )
+        })}
+      </svg>
+      <div className={styles.pieChart__info}>
+        {keyWordRank.map((el, idx) => (
+          <>
+            <div
+              className={styles['pieChart__info--box']}
+              style={{ backgroundColor: pieColour[idx] }}></div>
+            <div key={idx}>{el.keyWord}</div>
+          </>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default PieChart

--- a/src/components/PieChart/PieChart.module.css
+++ b/src/components/PieChart/PieChart.module.css
@@ -1,0 +1,17 @@
+.pieChart__container {
+  width: 150px;
+  height: 150px;
+}
+
+.pieChart__info {
+  display: flex;
+  justify-content: space-evenly;
+  margin-top: 12px;
+  font-size: 10px;
+  font-weight: 550;
+}
+
+.pieChart__info--box {
+  width: 10px;
+  height: 10px;
+}

--- a/src/components/PieChart/PieChart.module.css
+++ b/src/components/PieChart/PieChart.module.css
@@ -1,12 +1,15 @@
 .pieChart__container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
   width: 150px;
-  height: 150px;
+  height: 200px;
 }
 
 .pieChart__info {
   display: flex;
   justify-content: space-evenly;
-  margin-top: 12px;
+  align-items: center;
   font-size: 10px;
   font-weight: 550;
 }


### PR DESCRIPTION
### 변경 사항

키워드 랭킹의 Pie Chart 부분을 구현

### PR Point

- keyWord의 count가 차지하는 비율로 circle을 호의 길이를 구하고 stroke-dashArray에 전체 호의 길이를 줘서 반복안되게 함


### 참고 사항

- pieChart component는 keyWord totalCount와 keyWordRank를 props로 받는다고 가정하고 생성
- keyWordRank는 이전 단에서 [1등, 2등, 3등, others] 형태로 주어져야함
  (각각 {keyWord: String, count: Int} 형태이고 1, 2, 3등 및 others count의 총합은 totalCount와 같아야함)
- svg > circle을 이용해서 해당 keyWord의 비율만큼 호를 만든다음에 rotate 시키는 방식

예시
<img width="169" alt="스크린샷 2021-09-27 오전 12 56 51" src="https://user-images.githubusercontent.com/87363088/134815222-0c8f7d2a-8118-4a2c-a35d-181206385772.png">
